### PR TITLE
Making comparison more user friendly

### DIFF
--- a/fuzzyhashlib/__init__.py
+++ b/fuzzyhashlib/__init__.py
@@ -133,7 +133,7 @@ class sdhash(object):
 
     Attributes:
 
-    name -- the name of the alogorthm being used (ie. "sdhash")
+    name -- the name of the algorithm being used (ie. "sdhash")
     
     Operators:
         
@@ -143,9 +143,9 @@ class sdhash(object):
     name = "sdhash"
 
     def __init__(self, buf=None, hash=None):
-        """Initialises a ssdeep object. Can be initialised with either a
+        """Initialises a sdhash object. Can be initialised with either a
         a buffer through the use of the keyword argument 'buf' or a
-        previously computed ssdeep hash using the keyword agument ('hash').
+        previously computed sdhash hash using the keyword argument ('hash').
 
         Note that sdhash objects do not support update().
 
@@ -183,4 +183,12 @@ class sdhash(object):
         return score
 
     def __eq__(self, b):
-        return self._sdbf.compare(b._sdbf, 0) == 100
+        if isinstance(self, sdhash) and isinstance(b, sdhash):
+            return self.hexdigest() == b.hexdigest()
+        elif isinstance(self, sdhash) and isinstance(b, basestring):
+            return self.hexdigest() == b
+        else:
+            return False
+
+
+

--- a/fuzzyhashlib/__init__.py
+++ b/fuzzyhashlib/__init__.py
@@ -1,5 +1,4 @@
 from __future__ import print_function, absolute_import
-import inspect
 from . import libssdeep_wrapper
 from . import sdhash_wrapper
 
@@ -29,7 +28,7 @@ class ssdeep(object):
     
     ssdeep objects can be created either with a buffer or with a 
     previously computed hexdigest, although it should be noted that
-    objects created with a previously computed hash cannoy be updated
+    objects created with a previously computed hash cannot be updated
     with calls to their .update() method. Doing so will result in an
     InvalidOperation exception.
 
@@ -41,7 +40,7 @@ class ssdeep(object):
 
     Attributes:
 
-    name -- the name of the alogorthm being used (ie. "ssdeep")
+    name -- the name of the algorithm being used (ie. "ssdeep")
     digest_size -- the maximum size in bytes
     
     Operators:
@@ -55,7 +54,7 @@ class ssdeep(object):
     def __init__(self, buf=None, hash=None):
         """Initialises a ssdeep object. Can be initialised with either a
         a buffer through the use of the keyword argument 'buf' or a
-        previously computed ssdeep hash using the keyword agument ('hash').
+        previously computed ssdeep hash using the keyword argument ('hash').
         
         Note that only objects initialised using a buffer can be updated.
 
@@ -80,7 +79,6 @@ class ssdeep(object):
         except AttributeError:
             # On Python shutdown it seems like libssdeep_wrapper may get
             # freed first, it seems?
-            #print("?", end="")
             pass
 
     def hexdigest(self):
@@ -95,7 +93,7 @@ class ssdeep(object):
         if self._updatable:
             return libssdeep_wrapper.fuzzy_update(self._state, buf)
         else:
-            raise InvalidOperation("cannot update sdeep created from hash")
+            raise InvalidOperation("Cannot update sdeep created from hash")
 
     def copy(self):
         """Returns a new instance which identical to this instance."""
@@ -172,17 +170,17 @@ class sdhash(object):
         """Returns a new instance which identical to this instance."""
         return sdhash(hash=self.hexdigest())
 
+    @staticmethod
     def update(self, *args):
         """Not supported."""
-        raise InvalidOperation("update() not supported for sdhash.")
+        raise InvalidOperation("Update() not supported for sdhash.")
 
     def __sub__(self, b):
         score = self._sdbf.compare(b._sdbf, 0)
-        #print("SDHASH\n%s - %s = %d" % \
-        #        (self.hexdigest()[:32], b.hexdigest()[:32], score))
         return score
 
     def __eq__(self, b):
+        # This comparison is more user friendly
         if isinstance(self, sdhash) and isinstance(b, sdhash):
             return self.hexdigest() == b.hexdigest()
         elif isinstance(self, sdhash) and isinstance(b, basestring):

--- a/fuzzyhashlib/common.py
+++ b/fuzzyhashlib/common.py
@@ -51,7 +51,7 @@ def load_library(library_path):
     return library
 
 
-if sys.version_info[0] < 3: #major 
+if sys.version_info[0] < 3:  # major
     def tobyte(s): 
         return s 
 else: 
@@ -62,7 +62,7 @@ else:
             return s.encode('utf-8', errors='ignore') 
  
 
-if sys.version_info[0] < 3: #major 
+if sys.version_info[0] < 3:  # major
     def frombyte(s): 
         return s 
 else: 
@@ -70,4 +70,4 @@ else:
         if type(s) is bytes: 
             return str(s.decode(encoding='utf-8', errors='ignore')) 
         else: 
-             return s 
+            return s

--- a/fuzzyhashlib/libssdeep_wrapper.py
+++ b/fuzzyhashlib/libssdeep_wrapper.py
@@ -1,9 +1,4 @@
 from __future__ import absolute_import
-import sys
-import os
-import platform
-
-import ctypes
 from ctypes import *
 
 from .common import find_library, load_library, tobyte, frombyte
@@ -18,20 +13,23 @@ A ctypes wrapper for ssdeep version 2.9
 libssdeep_path = find_library("libssdeep")
 libssdeep = load_library(libssdeep_path)
 
-#defines (from fuzzy.h)
+# defines (from fuzzy.h)
 SPAMSUM_LENGTH = 64
 FUZZY_MAX_RESULT = 2 * SPAMSUM_LENGTH + 20
 FUZZY_FLAG_ELIMSEQ = 1
 FUZZY_FLAG_NOTRUNC = 2
+
 
 class SsdeepError(Exception):
     """Base exception class for SSDeep errors."""
     pass
 
 
-#fuzzy_new C API (from fuzzy.h)
-#extern /*@only@*/ /*@null@*/ struct fuzzy_state *fuzzy_new(void);
+# fuzzy_new C API (from fuzzy.h)
+# extern /*@only@*/ /*@null@*/ struct fuzzy_state *fuzzy_new(void);
 libssdeep.fuzzy_new.restype = c_void_p
+
+
 def fuzzy_new():
     result = libssdeep.fuzzy_new()
     if result is None:
@@ -39,39 +37,47 @@ def fuzzy_new():
     return result
 
 
-#fuzzy_clone C API (from fuzzy.h)
-#extern /*@only@*/ /*@null@*/ struct fuzzy_state *fuzzy_clone(const struct fuzzy_state *state);
+# fuzzy_clone C API (from fuzzy.h)
+# extern /*@only@*/ /*@null@*/ struct fuzzy_state *fuzzy_clone(const struct fuzzy_state *state);
 libssdeep.fuzzy_clone.restype = c_void_p
 libssdeep.fuzzy_clone.argtypes = [c_void_p]
+
+
 def fuzzy_clone(state):
     return libssdeep.fuzzy_clone(state)
 
 
-#fuzzy_free C API (from fuzzy.h)
-#extern void fuzzy_free(/*@only@*/ struct fuzzy_state *state);
+# fuzzy_free C API (from fuzzy.h)
+# extern void fuzzy_free(/*@only@*/ struct fuzzy_state *state);
 libssdeep.fuzzy_clone.argtypes = [c_void_p]
+
+
 def fuzzy_free(state):
     libssdeep.fuzzy_free(state)
 
 
-#fuzzy_update C API (from fuzzy.h)
-#extern int fuzzy_update(struct fuzzy_state *state,
+# fuzzy_update C API (from fuzzy.h)
+# extern int fuzzy_update(struct fuzzy_state *state,
 #            const unsigned char *buffer,
 #            size_t buffer_size);
 libssdeep.fuzzy_update.restype = c_int
 libssdeep.fuzzy_update.argtypes = [c_void_p, c_char_p, c_size_t]
+
+
 def fuzzy_update(state, buf):
     ret_code = libssdeep.fuzzy_update(state, tobyte(buf), len(buf))
     if ret_code != 0:
         raise SsdeepError("Could not update digest from passed buf.")
 
 
-#fuzzy_digest C API (from fuzzy.h)
-#extern int fuzzy_digest(const struct fuzzy_state *state,
+# fuzzy_digest C API (from fuzzy.h)
+# extern int fuzzy_digest(const struct fuzzy_state *state,
 #            /*@out@*/ char *result,
 #            unsigned int flags);
 libssdeep.fuzzy_digest.restype = c_int
 libssdeep.fuzzy_digest.argtypes = [c_void_p, c_char_p, c_uint]
+
+
 def fuzzy_digest(state, flags):
     result = create_string_buffer(FUZZY_MAX_RESULT)
     ret_code = libssdeep.fuzzy_digest(state, result, flags)
@@ -80,18 +86,18 @@ def fuzzy_digest(state, flags):
     return frombyte(result).value
 
 
-#fuzzy_set_total_input_length C API (from fuzzy.h)
-#extern int fuzzy_set_total_input_length(struct fuzzy_state *state, uint_least64_t total_fixed_length);
-#libssdeep.fuzzy_set_total_input_length.restype = c_int
-#libssdeep.fuzzy_set_total_input_length.argtypes = [c_void_p, c_ulonglong]
-#def fuzzy_set_total_input_length(state, total_fixed_length):
-#    return libssdeep.fuzzy_set_total_input_length(state, total_fixed_length)
+# fuzzy_set_total_input_length C API (from fuzzy.h)
+# extern int fuzzy_set_total_input_length(struct fuzzy_state *state, uint_least64_t total_fixed_length);
+# libssdeep.fuzzy_set_total_input_length.restype = c_int
+# libssdeep.fuzzy_set_total_input_length.argtypes = [c_void_p, c_ulonglong]
+# def fuzzy_set_total_input_length(state, total_fixed_length):
+#     return libssdeep.fuzzy_set_total_input_length(state, total_fixed_length)
 
 
-#fuzzy_compare C API (from fuzzy.h)
-#extern int fuzzy_compare(const char *sig1, const char *sig2);
-#libssdeep.fuzzy_compare.restype = c_int
-#libssdeep.fuzzy_compare.argtypes = [c_char_p, c_char_p]
+# fuzzy_compare C API (from fuzzy.h)
+# extern int fuzzy_compare(const char *sig1, const char *sig2);
+# libssdeep.fuzzy_compare.restype = c_int
+# libssdeep.fuzzy_compare.argtypes = [c_char_p, c_char_p]
 def compare(sig1, sig2):
     """Computes the match score between the two two passed fuzzy hashes.
     This will be an integer score between 0 and 100.

--- a/fuzzyhashlib/sdbf_class.py
+++ b/fuzzyhashlib/sdbf_class.py
@@ -4,10 +4,6 @@
 # Do not make changes to this file unless you know what you are doing--modify
 # the SWIG interface file instead.
 
-
-
-
-
 from sys import version_info
 if version_info >= (2,6,0):
     def swig_import_helper():

--- a/fuzzyhashlib/sdhash_wrapper.py
+++ b/fuzzyhashlib/sdhash_wrapper.py
@@ -1,10 +1,8 @@
 from __future__ import print_function
 import sys
 import os
-import platform
-import hashlib
 
-from . common import find_library, load_library, tobyte, frombyte
+from . common import find_library
 
 """
 Shim between fuzzyhashlib code and sdhash's existing sdbf_class module (which


### PR DESCRIPTION
__eq__ now compares the hexdigests as opposed to the hashes themselves. This way if one of them is a string already then it will still return True.